### PR TITLE
SlackAPIErrorの時に実行結果を見れるようにする

### DIFF
--- a/src/slack_client.py
+++ b/src/slack_client.py
@@ -33,7 +33,7 @@ def send_image_to_thread(image_path) -> None:
         # Log the result
         logger.info(f"Screenshot uploaded: {image_path}")
     except SlackApiError as e:
-        logger.debug(f"Error: {e}")
+        logger.info(f"Error: {e}")
     except Exception:
         raise
 


### PR DESCRIPTION
### これは何

AutehnticationErrorを識別する部分のloggerレベルを引き上げ。
debugのままだと実行時にみられなかった。